### PR TITLE
Fixed critical env bug

### DIFF
--- a/bfabric_web_apps/objects/BfabricInterface.py
+++ b/bfabric_web_apps/objects/BfabricInterface.py
@@ -88,7 +88,8 @@ class BfabricInterface( Bfabric ):
             if current_time > datetime.datetime.strptime(expiry_time, "%Y-%m-%d %H:%M:%S") + datetime.timedelta(days=7):
                 return "EXPIRED"
             
-            environment_dict = {"Production":"https://fgcz-bfabric.uzh.ch/bfabric","Test":"https://fgcz-bfabric-test.uzh.ch/bfabric"}
+            envioronment_name = str(userinfo['environment']).strip().lower()
+            environment_dict = {"production":"https://fgcz-bfabric.uzh.ch/bfabric","prod":"https://fgcz-bfabric.uzh.ch/bfabric","test":"https://fgcz-bfabric-test.uzh.ch/bfabric"}
             
             token_data = dict(
                 environment = userinfo['environment'],
@@ -96,7 +97,7 @@ class BfabricInterface( Bfabric ):
                 token_expires = expiry_time,
                 entity_id_data = userinfo['entityId'],
                 entityClass_data = userinfo['entityClassName'],
-                webbase_data = environment_dict.get(userinfo['environment'], None),
+                webbase_data = environment_dict[envioronment_name],
                 application_params_data = {},
                 application_data = str(userinfo['applicationId']),
                 userWsPassword = userinfo['userWsPassword'],
@@ -129,10 +130,9 @@ class BfabricInterface( Bfabric ):
         Returns:
             Bfabric: An authenticated Bfabric instance.
         """
-
+     
         bfabric_auth = BfabricAuth(login=token_response.get('user_data'), password=token_response.get('userWsPassword'))
-        bfabric_client_config = BfabricClientConfig(base_url=token_response.get('webbase_data')) 
-
+        bfabric_client_config = BfabricClientConfig(base_url=token_response['webbase_data'])
         bfabric_wrapper = bfabric.Bfabric(config=bfabric_client_config, auth=bfabric_auth)
 
         return bfabric_wrapper


### PR DESCRIPTION
The error occurred because the API changed the value of `userinfo['environment']` from `'Test'` to `'TEST'`. 
This led to a problem in `Bfabric_web_apps.BfabricInterface`, line 93, where the environment lookup returned `None`: 

environment_dict.get(userinfo['environment'], None) 

As a result, the following line defaulted to the production system URL: 
 
bfabric_client_config = BfabricClientConfig(base_url=token_response.get('webbase_data'))